### PR TITLE
Add a terragrunt.hcl file as well for testing purposes

### DIFF
--- a/terragrunt.hcl
+++ b/terragrunt.hcl
@@ -1,0 +1,3 @@
+inputs = {
+  foo = "bar"
+}


### PR DESCRIPTION
With the update to terragrunt v0.19, we no longer support `terraform.tfvars` for terragrunt config and inputs and instead rely on `terragrunt.hcl`. So we also need an example of updating vars in `terragrunt.hcl` inputs attribute.

Note that this isn't replacing the `terraform.tfvars` file, because we want to continue to support that workflow as well since not everyone uses terragrunt.